### PR TITLE
fix for omx when performing GST build

### DIFF
--- a/autoapp/CMakeLists.txt
+++ b/autoapp/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(autoapp
         openauto
         )
 
-if(RPI_BUILD)
+if(RPI_BUILD AND NOT GST_BUILD)
     target_link_libraries(autoapp omx)
 endif()
 


### PR DESCRIPTION
Check to see if build is raspberry Pi and not Gstreamer before linking OMX 