### PR TITLE
Fix install for btservice_proto

### DIFF
--- a/btservice_proto/CMakeLists.txt
+++ b/btservice_proto/CMakeLists.txt
@@ -8,6 +8,6 @@ add_library(btservice_proto SHARED ${proto_headers} ${proto_sources})
 target_link_libraries(btservice_proto ${PROTOBUF_LIBRARIES})
 
 install(TARGETS btservice_proto DESTINATION lib)
-install(DIRECTORY . DESTINATION include/btservice_proto
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} DESTINATION include
         FILES_MATCHING PATTERN *.h
         PATTERN CMakeFiles EXCLUDE)


### PR DESCRIPTION
Same as: https://github.com/openDsh/aasdk/pull/14

The changes in https://github.com/openDsh/dash/pull/37 to make aasdk and openauto build in a subdirectory triggered a bug in the btservice_proto cmake config to fail to install files and caused compile to fail.

In order to fix this I changed it to install based on the binary directory instead of the current directory and this appears to have solved the problem.
