### PR TITLE
RtAudio white screen fix

### DIFF
--- a/include/openauto/Projection/RtAudioOutput.hpp
+++ b/include/openauto/Projection/RtAudioOutput.hpp
@@ -50,7 +50,7 @@ private:
     uint32_t sampleRate_;
     SequentialBuffer audioBuffer_;
     std::unique_ptr<RtAudio> dac_;
-    std::mutex mutex_;
+    static std::mutex mutex_;
 };
 
 }

--- a/openauto/Projection/RtAudioOutput.cpp
+++ b/openauto/Projection/RtAudioOutput.cpp
@@ -24,6 +24,8 @@ namespace openauto
 namespace projection
 {
 
+std::mutex RtAudioOutput::mutex_;
+
 RtAudioOutput::RtAudioOutput(uint32_t channelCount, uint32_t sampleSize, uint32_t sampleRate)
     : channelCount_(channelCount)
     , sampleSize_(sampleSize)


### PR DESCRIPTION
This change makes the RtAudioOutput mutex static (shared) across instances, serializing calls to RtAudio (open, start stream, stop stream, and calls to the audio buffer read handler).

I believe the issue occurs because the three RtAudioOutput instances (music, speech, and system) running in separate threads attempt to access RtAudio simultaneously causing RtAudio to hang. My guess is that because not all audio channel requests are responded to, future requests are not made (i.e. opening the video channel) and this leads to the white screen. I haven't gone through the source enough to say for sure but I think this is the case.

These changes fixed the white screen issue I had using RtAudio on my Raspberry Pi 4B. I did about an hours worth of testing including numerous phone connection cycles and reboots and never saw the white screen nor noticed any performance issues such as audio stuttering.

It's possible these changes can be further optimized; perhaps the mutex synchronization across threads is not needed at all points (maybe just during open / start stream). My intent is to share a solution and see if it helps others as I know it is quite a prevalent issue.